### PR TITLE
docs(cv): update PDF resume content and print layout

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -1,8 +1,16 @@
 import type { ReactNode } from 'react';
 import { cvData } from './data';
 
-const Section = ({ title, children }: { title: string; children: ReactNode }) => (
-  <section className="section-card">
+const Section = ({
+  title,
+  children,
+  className,
+}: {
+  title: string;
+  children: ReactNode;
+  className?: string;
+}) => (
+  <section className={`section-card ${className ?? ''}`.trim()}>
     <h2>{title}</h2>
     {children}
   </section>
@@ -24,7 +32,6 @@ function App() {
         </div>
         <div className="hero-meta">
           <p>{cvData.profile.location}</p>
-          <p>{cvData.profile.domain}</p>
           <div className="mini-card">
             <h3>Current Position</h3>
             <p>
@@ -40,7 +47,7 @@ function App() {
           <div className="links">
             {cvData.profile.links.map((item) => (
               <a key={item.href} href={item.href} target="_blank" rel="noreferrer">
-                {item.label}
+                {item.text ?? item.label}
               </a>
             ))}
           </div>
@@ -50,7 +57,7 @@ function App() {
         </div>
       </header>
 
-      <Section title="Current Company & Role">
+      <Section title="Current Company & Role" className="current-company-section">
         <article className="mini-card">
           <h3>
             {cvData.profile.currentCompany.name} · {cvData.profile.currentCompany.role}
@@ -69,7 +76,7 @@ function App() {
         </article>
       </Section>
 
-      <Section title="Core Competencies">
+      <Section title="Core Competencies" className="post-hero-break">
         <div className="grid-2">
           {cvData.competencies.map((group) => (
             <article key={group.title} className="mini-card">
@@ -141,6 +148,10 @@ function App() {
           <article>
             <h3>Data</h3>
             <p>{cvData.skills.data.join(' · ')}</p>
+          </article>
+          <article>
+            <h3>AI</h3>
+            <p>{cvData.skills.ai.join(' · ')}</p>
           </article>
         </div>
       </Section>

--- a/docs/src/data.ts
+++ b/docs/src/data.ts
@@ -5,14 +5,14 @@ export const cvData = {
     name: 'Hun Jang',
     alias: 'HunyDev',
     role: 'AI 음성합성(TTS) 개발자 · Software Engineer',
-    location: 'Seoul, South Korea',
-    domain: 'huny.dev',
+    location: 'Sejong, South Korea',
     summary:
       'TTS 추론 엔진, API/SDK, 클라우드 서비스 개발·운영 경험을 중심으로 백엔드/플랫폼 개발을 수행합니다. 업무 자동화와 AI 기반 서비스 실험을 병행하며, 아이디어-개발-배포까지 빠르게 연결하는 실행력을 강점으로 합니다.',
     links: [
-      { label: 'Portfolio', href: 'https://huny.dev' },
-      { label: 'GitHub', href: 'https://github.com/hunydev' },
-      { label: 'Email', href: 'mailto:contact@huny.dev' },
+      { label: 'Portfolio', href: 'https://huny.dev', text: 'Portfolio: https://huny.dev' },
+      { label: 'GitHub', href: 'https://github.com/hunydev', text: 'GitHub: https://github.com/hunydev' },
+      { label: 'Blog', href: 'https://blog.huny.dev', text: 'Blog: https://blog.huny.dev' },
+      { label: 'Email', href: 'mailto:jang@huny.dev', text: 'Email: jang@huny.dev' },
     ],
     currentCompany: {
       name: 'SELVAS AI',
@@ -108,25 +108,16 @@ export const cvData = {
       links: ['https://huny.dev', 'https://github.com/hunydev/huny.dev'],
     },
     {
-      name: 'Prompt Keeper',
-      desc: 'AI 프롬프트 저장/관리용 웹앱. 서버리스 구조로 운영.',
-      links: ['https://prompts.huny.dev', 'https://github.com/hunydev/prompt-keeper'],
-    },
-    {
       name: 'AutoPad',
       desc: 'Windows 생산성 향상을 위한 클립보드 자동화 도구.',
-      links: ['https://autopad.huny.dev', 'https://github.com/hunydev/autopad'],
-    },
-    {
-      name: 'JWT Encoder/Decoder',
-      desc: '실시간 JWT 인코딩/디코딩과 서명 검증을 지원하는 유틸리티 웹앱.',
-      links: ['https://jwt.huny.dev', 'https://github.com/hunydev/jwt-huny-dev'],
+      links: ['https://autopad.huny.dev', 'https://github.com/hunydev/autopad', 'https://apps.microsoft.com/detail/9p63pjdml1x0'],
     },
   ],
   skills: {
-    languages: ['Go', 'C', 'C++', 'Python', 'Java', 'TypeScript', 'JavaScript', 'C#'],
+    languages: ['Go', 'C', 'Python', 'Java', 'JavaScript', 'C#'],
     infra: ['AWS', 'Cloudflare', 'Netlify', 'Docker', 'GitHub Actions', 'Jenkins'],
     tools: ['VS Code', 'Visual Studio', 'STS', 'Notion', 'JIRA', 'Confluence'],
     data: ['MySQL', 'SQLite', 'MongoDB', 'Redis', 'Cassandra'],
+    ai: ['GitHub Copilot', 'Claude', 'Gemini', 'Codex', 'ChatGPT'],
   },
 };

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -220,4 +220,31 @@ ul {
     color: #111;
     text-decoration: none;
   }
+
+  .hero {
+    padding: 18px;
+    gap: 14px;
+  }
+
+  .hero-meta {
+    padding: 10px;
+  }
+
+  .section-card {
+    margin-top: 10px;
+    padding: 14px;
+  }
+
+  .section-card h2 {
+    margin-bottom: 10px;
+  }
+
+  .current-company-section {
+    break-inside: avoid;
+  }
+
+  .post-hero-break {
+    break-before: page;
+  }
 }
+


### PR DESCRIPTION
### Motivation
- Improve the PDF-export readability and accuracy of the CV by updating location, contact/link presentation, projects, and skill groups for printable output.
- Ensure the header and `Current Company & Role` block remain on the first PDF page and subsequent sections start cleanly on the next page.

### Description
- Updated profile data in `docs/src/data.ts`: changed `location` to `Sejong, South Korea`, removed the separate `domain` display, added printable link text for `Portfolio`, `GitHub`, and new `Blog`, and updated email to `jang@huny.dev`.
- Adjusted `projects` in `docs/src/data.ts` by removing `Prompt Keeper` and `JWT Encoder/Decoder` and adding the Microsoft Store link to `AutoPad` (`https://apps.microsoft.com/detail/9p63pjdml1x0`).
- Modified `skills` in `docs/src/data.ts` to remove `C++` and `TypeScript` from `languages` and added a new `ai` group with `GitHub Copilot, Claude, Gemini, Codex, ChatGPT` and reflected the `AI` panel in `docs/src/App.tsx`.
- Updated `docs/src/App.tsx` to render link text (`item.text ?? item.label`), removed domain line under the header, added `className` support to the `Section` component, and applied `current-company-section` and `post-hero-break` classes to control print breaks.
- Tweaked print CSS in `docs/src/styles.css` to tighten header/section spacing and added rules (`.current-company-section`, `.post-hero-break`, and spacing adjustments) so content through `Current Company & Role` stays on page one and following sections start on a new page.

### Testing
- Ran `npm run build` inside `docs/` and the production build completed successfully.
- No automated visual/PDF tests were run; manual PDF preview was the intended behavior and layout changes target print CSS rules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c488c9ce7c8329b194c32a3573b396)