### PR TITLE
feat(docs-cv): add local profile photo upload for PDF export

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useEffect, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
 import { cvData } from './data';
 
 const Section = ({
@@ -17,6 +17,46 @@ const Section = ({
 );
 
 function App() {
+  const [photoPreviewUrl, setPhotoPreviewUrl] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    return () => {
+      if (photoPreviewUrl) {
+        URL.revokeObjectURL(photoPreviewUrl);
+      }
+    };
+  }, [photoPreviewUrl]);
+
+  const handleUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handlePhotoChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    if (photoPreviewUrl) {
+      URL.revokeObjectURL(photoPreviewUrl);
+    }
+
+    const objectUrl = URL.createObjectURL(file);
+    setPhotoPreviewUrl(objectUrl);
+  };
+
+  const handlePhotoClear = () => {
+    if (photoPreviewUrl) {
+      URL.revokeObjectURL(photoPreviewUrl);
+      setPhotoPreviewUrl(null);
+    }
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
   const handlePrint = () => window.print();
 
   return (
@@ -54,6 +94,30 @@ function App() {
           <button onClick={handlePrint} className="print-btn" type="button">
             PDF Export
           </button>
+          <input
+            ref={fileInputRef}
+            className="photo-input"
+            type="file"
+            accept="image/*"
+            onChange={handlePhotoChange}
+          />
+          <div className={`photo-upload ${photoPreviewUrl ? 'has-photo' : ''}`}>
+            {photoPreviewUrl ? (
+              <img src={photoPreviewUrl} alt="Profile preview" className="profile-photo" />
+            ) : (
+              <p className="photo-placeholder">PDF 내보내기 전에 증명사진을 업로드하세요.</p>
+            )}
+            <div className="photo-actions">
+              <button onClick={handleUploadClick} className="upload-btn" type="button">
+                {photoPreviewUrl ? '사진 변경' : '사진 업로드'}
+              </button>
+              {photoPreviewUrl && (
+                <button onClick={handlePhotoClear} className="clear-btn" type="button">
+                  사진 제거
+                </button>
+              )}
+            </div>
+          </div>
         </div>
       </header>
 

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -110,6 +110,58 @@ a:hover {
   cursor: pointer;
 }
 
+.photo-input {
+  display: none;
+}
+
+.photo-upload {
+  margin-top: 10px;
+  border: 1px dashed #7dd3fc4f;
+  border-radius: 10px;
+  padding: 10px;
+  background: #7dd3fc0a;
+}
+
+.photo-placeholder {
+  margin: 0 0 8px;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.profile-photo {
+  width: 100%;
+  max-width: 140px;
+  height: 176px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  object-fit: cover;
+  display: block;
+}
+
+.photo-actions {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.upload-btn,
+.clear-btn {
+  border: 1px solid #7dd3fc4f;
+  border-radius: 8px;
+  background: #7dd3fc1a;
+  color: #d9f3ff;
+  padding: 6px 10px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.clear-btn {
+  border-color: #fca5a54f;
+  background: #fca5a51a;
+  color: #ffe2e2;
+}
+
 .section-card {
   margin-top: 16px;
   padding: 20px;
@@ -216,27 +268,62 @@ ul {
     display: none;
   }
 
+  .photo-actions {
+    display: none;
+  }
+
   a {
     color: #111;
     text-decoration: none;
   }
 
   .hero {
-    padding: 18px;
-    gap: 14px;
+    padding: 14px;
+    gap: 10px;
+  }
+
+  .hero h1 {
+    font-size: 1.7rem;
+  }
+
+  .hero .summary {
+    font-size: 0.92rem;
   }
 
   .hero-meta {
-    padding: 10px;
+    padding: 8px;
+  }
+
+  .photo-upload {
+    margin-top: 8px;
+    border: 1px solid #d1d5db;
+    background: #fff;
+    padding: 8px;
+  }
+
+  .photo-placeholder {
+    display: none;
+  }
+
+  .photo-upload.has-photo {
+    display: flex;
+    justify-content: center;
+  }
+
+  .profile-photo {
+    width: 106px;
+    height: 132px;
+    max-width: none;
+    border-color: #d1d5db;
   }
 
   .section-card {
-    margin-top: 10px;
-    padding: 14px;
+    margin-top: 8px;
+    padding: 12px;
   }
 
   .section-card h2 {
-    margin-bottom: 10px;
+    margin-bottom: 8px;
   }
 
   .current-company-section {
@@ -247,4 +334,3 @@ ul {
     break-before: page;
   }
 }
-


### PR DESCRIPTION
### Motivation
- CV 페이지에서 서버 업로드 없이 브라우저에서만 프로필 사진을 올려 PDF(브라우저 print)로 내보낼 수 있도록 하여 GitHub 등 외부에 사진이 올라가지 않게 하려는 목적입니다.
- 사진을 추가해도 `Current Company & Role` 섹션이 1페이지를 벗어나지 않도록 인쇄 레이아웃을 조정해야 합니다.

### Description
- `docs/src/App.tsx`에 로컬 전용 사진 업로드 로직을 추가하고 `photoPreviewUrl`, `fileInputRef`, `handlePhotoChange`, `handleUploadClick`, `handlePhotoClear` 상태/핸들러와 `URL.createObjectURL`/`URL.revokeObjectURL` 기반 정리 로직을 구현했습니다.
- hero 메타 영역에 숨김 `input[type=file]`과 업로드/변경/제거 버튼 및 미리보기 `<img>` 요소를 추가해 사용자가 인쇄 전 사진을 바로 반영할 수 있게 했습니다.
- `docs/src/styles.css`에 업로드 UI용 클래스(`.photo-upload`, `.profile-photo`, `.photo-actions`, 등)를 추가하고 인쇄 미디어 쿼리에서 액션 버튼 숨김, 간격/폰트/사진 크기 축소 등 레이아웃 튜닝을 적용해 사진이 포함되더라도 주요 섹션이 1페이지에 머무르도록 조정했습니다.
- 서버 업로드나 영속 저장은 전혀 수행하지 않으며 모든 처리는 브라우저 메모리/객체 URL 범위에서만 이루어집니다.

### Testing
- 실행 빌드로 `npm --prefix docs run build`를 수행했으며 Vite 빌드가 정상 완료되었습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c48ec4634c8329a2cc742dff8a61d7)