### PR TITLE
Enable GitHub Pages preview deployments for pull requests

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages-${{ github.event_name }}-${{ github.ref }}
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -55,7 +55,6 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/pages.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -14,7 +18,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -51,6 +55,7 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -60,3 +65,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          preview: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
### Motivation
- Allow previewing the site for feature branches when a PR touches `docs` or the Pages workflow instead of only deploying on `main` pushes.
- Avoid cross-branch cancellation of in-progress workflows so concurrent PRs/branches can build and preview independently.

### Description
- Add a `pull_request` trigger scoped to `docs/**` and `.github/workflows/pages.yml` in `.github/workflows/pages.yml` so PRs run the Pages workflow.
- Change `concurrency.group` to `pages-${{ github.event_name }}-${{ github.ref }}` to isolate concurrency by event and ref.
- Make the `deploy` job conditional on the event and pass `preview: ${{ github.event_name == 'pull_request' }}` to `actions/deploy-pages@v4` so PRs produce preview deployments while pushes keep normal behavior.

### Testing
- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pages.yml'); puts 'YAML OK'"` which printed `YAML OK` indicating the workflow file parsed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4933f2f3c8329a9fba15db6a54e27)